### PR TITLE
Fix empty bubble being drawn on cleared canvas.

### DIFF
--- a/scripts/ccharter.js
+++ b/scripts/ccharter.js
@@ -13,7 +13,10 @@ var ChordCharter = {
 	
 		var origin = { x: originX, y: originY };
 		var props = { width: 50, height: 60 };
-	
+
+		// Reset previous path that may have been created.
+		ctx.beginPath();
+
 		// horizontals
 	
 		for (counter in new Array(0, 1, 2, 3, 4)) {


### PR DESCRIPTION
When a canvas had been cleared, it would leave behind a bubble from where the last chord dot had been placed.

<img width="81" alt="screen shot 2017-04-30 at 7 40 13 pm" src="https://cloud.githubusercontent.com/assets/12452738/25569049/0252821c-2ddd-11e7-8deb-6bef4116fcb6.png">
<img width="93" alt="screen shot 2017-04-30 at 7 40 07 pm" src="https://cloud.githubusercontent.com/assets/12452738/25569053/12f39156-2ddd-11e7-8c4a-76adf3401954.png">

Test with
```js
var canvas = $("#chordy")[0];
var context = canvas.getContext('2d');
ChordCharter.drawChord("chordy", 30, 25, "", "111111");
context.clearRect(0, 0, canvas.width, canvas.height);
ChordCharter.drawChord("chordy", 30, 25, "", "222222");
```